### PR TITLE
Update for compatability with Laravel 5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         }
     },
     "require": {
-        "laravel/framework": "~5.1",
+        "laravel/framework": "~5.2",
         "optimus/onion": "0.1.x"
     },
     "require-dev": {

--- a/src/Provider/LaravelServiceProvider.php
+++ b/src/Provider/LaravelServiceProvider.php
@@ -22,7 +22,7 @@ class LaravelServiceProvider extends BaseProvider {
 
     public function bindInstance()
     {
-        $this->app->bindShared('uploader', function(){
+        $this->app->singleton('uploader', function(){
             $config = new Config($this->app['config']->get('uploader'));
 
             $storage = $this->createStorage(


### PR DESCRIPTION
See the deprecations part of the [upgrade guide](https://laravel.com/docs/5.2/upgrade#upgrade-5.1.11). The `bindShared()` has been renamed to `singleton()` in Laravel 5.2
