### PR TITLE
fix: remove file extension from upload_path

### DIFF
--- a/src/Uploader.php
+++ b/src/Uploader.php
@@ -110,8 +110,13 @@ class Uploader {
             'type' => 'upload',
             'success' => true,
             'file_type' => $file->getType(),
-            'upload_path' => $file->getName()
+            'upload_path' => $this->clearFileExtension($file->getName())
         ]);
+    }
+    
+    private function clearFileExtension($fileName)
+    {
+        return substr($fileName, 0, (strrpos($fileName, ".")));
     }
 
     public function delete($upload_path){


### PR DESCRIPTION
Cloudinary work without extensions too.
Removed extension from upload_path because extension in upload_path (cloudinary public id) can cause problems on downloading images and generating archives
